### PR TITLE
add unHighlight even for attribute text

### DIFF
--- a/Highlighter/Highlightable.swift
+++ b/Highlighter/Highlightable.swift
@@ -13,6 +13,7 @@ public protocol Highlightable: class {
     var attributedTextValue: NSAttributedString? { get set }
 
     func highlight(text: String, normal normalAttributes: [NSAttributedString.Key : Any]?, highlight highlightAttributes: [NSAttributedString.Key : Any]?)
+    func unHighlight()
 }
 
 extension Highlightable {
@@ -30,5 +31,11 @@ extension Highlightable {
             normal: normalAttributes,
             highlight: highlightAttributes
         )
+    }
+    
+    public func unHighlight() {
+        if let attText = self.attributedTextValue {
+            attributedTextValue = NSAttributedString(string: attText.string)
+        }
     }
 }

--- a/Highlighter/HighlightableContainer.swift
+++ b/Highlighter/HighlightableContainer.swift
@@ -17,6 +17,7 @@ public protocol HighlightableContainer: class {
     ///   - highlightAttributes: Attributes to apply (highlight) to matching text
     ///   - type: (optional) Only search `Highlightable`s of this type
     func highlight(text: String, normal normalAttributes: [NSAttributedString.Key : Any]?, highlight highlightAttributes: [NSAttributedString.Key : Any]?, type: Highlightable.Type?)
+    func unHighlight(type: Highlightable.Type?)
 }
 
 extension HighlightableContainer {
@@ -26,6 +27,14 @@ extension HighlightableContainer {
             .compactMap { $0.value as? Highlightable }
             .filter { return type == nil || Swift.type(of: $0) == type }
             .forEach { $0.highlight(text: text, normal: normalAttributes, highlight: highlightAttributes) }
+    }
+    
+    public func unHighlight(type: Highlightable.Type? = nil) {
+        let mirror = Mirror(reflecting: self)
+        mirror.children
+            .compactMap { $0.value as? Highlightable }
+            .filter { return type == nil || Swift.type(of: $0) == type }
+            .forEach { $0.unHighlight() }
     }
 }
 


### PR DESCRIPTION
When the project use Highlighter to highlight cell, if the cell contain label using attribute string. This highlight method will make the label cache highlighted attribute string